### PR TITLE
Bump Newtonsoft.Json in /Samples/Sample.Prism.Windows.Simple

### DIFF
--- a/Samples/Sample.Prism.Windows.Simple/Sample.Prism.Windows.Simple.csproj
+++ b/Samples/Sample.Prism.Windows.Simple/Sample.Prism.Windows.Simple.csproj
@@ -156,7 +156,7 @@
       <Version>2.0.0</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>11.0.2</Version>
+      <Version>13.0.2</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup />


### PR DESCRIPTION
### Description

In this change, the version of the package reference for Newtonsoft.Json in the Sample.Prism.Windows.Simple.csproj file has been updated from 11.0.2 to 13.0.2.

- Update Newtonsoft.Json package reference version from 11.0.2 to 13.0.2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated `Newtonsoft.Json` package to version `13.0.2` for improved performance and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->